### PR TITLE
If locator type is not specified, try locating by id, then name

### DIFF
--- a/src/Selenium2WithAdapterTestCase.php
+++ b/src/Selenium2WithAdapterTestCase.php
@@ -62,7 +62,12 @@ class Selenium2WithAdapterTestCase extends \PHPUnit_Extensions_Selenium2TestCase
 
             }
         } else {
-            return $this->byName($selector);
+            try {
+                $return = $this->byId($selector);
+                return $return;
+            } catch (\PHPUnit_Extensions_Selenium2TestCase_WebDriverException $e) {
+                return $this->byName($selector);
+            }
         }
     }
 


### PR DESCRIPTION
This seems to be how SeleniumTestCase worked, although I'm not sure whether it tried id first or name first. I'm assuming id, because that seems more unique.
